### PR TITLE
reexport prelude contents from crate root, and add #[doc(inline)]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -138,5 +138,10 @@ pub mod tap;
 
 /// Reëxports all traits in one place, for easy import.
 pub mod prelude {
+  #[doc(inline)]
 	pub use crate::{conv::*, pipe::*, tap::*};
 }
+
+// also make traits available at crate root
+#[doc(inline)]
+pub use prelude::*;


### PR DESCRIPTION
I was going to open an issue, but I realized it would be easier to just open a PR to show what I meant.

For those of us that prefer named imports instead of glob imports, this makes it a little bit more convenient to do so. `use tap::tap::Tap;` is shortened to `use tap::Tap;`.

Note I also added `#[doc(inline)]`, so that the exported traits appear in the generated documentation at the crate root, instead of just seeing the glob import in the documentation. This is what it looks like now:

![Screen Shot 2020-11-21 at 3 04 07 PM](https://user-images.githubusercontent.com/6751033/99886636-252f0400-2c0c-11eb-89cc-657c56466d6a.png)

Let me know what you think!