### PR TITLE
Add traits for inline `AsRef` and `AsMut`.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -134,12 +134,13 @@ implementation, and does nothing else.
 
 pub mod conv;
 pub mod pipe;
+pub mod reffed;
 pub mod tap;
 
 /// Reëxports all traits in one place, for easy import.
 pub mod prelude {
 	#[doc(inline)]
-	pub use crate::{conv::*, pipe::*, tap::*};
+	pub use crate::{conv::*, pipe::*, reffed::*, tap::*};
 }
 
 // also make traits available at crate root

--- a/src/reffed.rs
+++ b/src/reffed.rs
@@ -1,0 +1,82 @@
+/*! # Method-Directed Reference-to-Reference Conversion
+
+The `std::convert` module provides traits for converting references from one
+to another ([`AsRef`] and [`AsMut`]).
+
+It is not always possible for the compiler to infer which reference type you're targeting.
+These traits put the type parameter in the method instead of the trait,
+so you can write [`.reffed::<T>()`][Reffed::reffed] for immutable references,
+and [`.ref_muted::<T>()`][RefMuted::ref_muted] for mutable ones.
+
+These traits are blanket-implemented on all types that have [`AsRef`] and [`AsMut`]
+implementations.
+*/
+
+/// Allows calling [`AsRef`] inline.
+pub trait Reffed {
+	/// Converts a reference to `Self` into a reference to `T`.
+	///
+	/// # Examples
+	/// ```rust
+	/// use tap::reffed::Reffed;
+	/// use std::path::Path;
+	///
+	/// let path_as_string = "/some/sort/of/path";
+	/// let displayable_path = path_as_string.reffed::<Path>()
+	///     .display();
+	///
+	/// assert_eq!(displayable_path.to_string(), path_as_string);
+	/// ```
+	fn reffed<T>(&self) -> &T
+	where
+		Self: AsRef<T>,
+		T: ?Sized;
+}
+
+impl<T> Reffed for T
+where
+	T: ?Sized,
+{
+	fn reffed<U>(&self) -> &U
+	where
+		T: AsRef<U>,
+		U: ?Sized,
+	{
+		self.as_ref()
+	}
+}
+
+/// Allows calling [`AsMut`] inline.
+pub trait RefMuted {
+	/// Converts a mutable reference to `Self` into a mutable reference to `T`.
+	///
+	/// # Examples
+	/// ```rust
+	/// use tap::reffed::RefMuted;
+	///
+	/// // This seems contrived because there's nothing
+	/// // in the rust stdlib that implements
+	/// // `AsMut` but not `DerefMut`.
+	/// let mut ascii_hi = vec![104, 105];
+	/// ascii_hi.ref_muted::<[u8]>().make_ascii_uppercase();
+	///
+	/// assert_eq!(std::str::from_utf8(&ascii_hi).unwrap(), "HI");
+	/// ```
+	fn ref_muted<T>(&mut self) -> &mut T
+	where
+		Self: AsMut<T>,
+		T: ?Sized;
+}
+
+impl<T> RefMuted for T
+where
+	T: ?Sized,
+{
+	fn ref_muted<U>(&mut self) -> &mut U
+	where
+		T: AsMut<U>,
+		U: ?Sized,
+	{
+		self.as_mut()
+	}
+}


### PR DESCRIPTION
`<T as AsRef<U>>.as_ref(t)` is too verbose, and breaks reading right-to-left. I figured this calls for a helper trait for `AsRef` and `AsMut` invocations.

Type inference is pretty good for spots that need you to pass a reference, but for _methods_ on those references, it's not so great. I encountered this when trying to use `Path::display` on an `OsStr` through `impl AsRef<Path> for OsStr`.

# Naming

I'm not married to the trait or method names. I'm actually torn between `Reffed::reffed` and `AsA::as_a`. Thoughts?

# Documentation

Is what I wrote sufficient? I copied a bit of the style from `Conv`, but mine is more sparse.